### PR TITLE
compat: Add shim for Fence destructor

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -274,6 +274,9 @@ cc_library {
 cc_library_shared {
     name: "libui_shim",
     shared_libs: ["libui"],
-    srcs: ["libui/GraphicBuffer.cpp"],
+    srcs: [
+        "libui/Fence.cpp",
+        "libui/GraphicBuffer.cpp",
+    ],
     compile_multilib: "64",
 }

--- a/libui/Fence.cpp
+++ b/libui/Fence.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2022 The LineageOS Project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// android::Fence::~Fence()
+extern "C" void _ZN7android5FenceD1Ev() {
+    // no-op, the explicit destructor was replaced with = default;
+}


### PR DESCRIPTION
* This was replaced with a default destructor which has no visible linkage. No-op the destructor call and hope the actual destructor is called from underneath.

Change-Id: Id039e916c24959e9f60391bc10886df878f4d265